### PR TITLE
Fix order of log and parser init in readMathMLFromString

### DIFF
--- a/src/sbml/math/MathML.cpp
+++ b/src/sbml/math/MathML.cpp
@@ -2272,8 +2272,8 @@ readMathMLFromString (const char *xml)
     needDelete = true;
   }
 
-  XMLInputStream stream(xmlstr_c, false);
   SBMLErrorLog   log;
+  XMLInputStream stream(xmlstr_c, false);
 
   stream.setErrorLog(&log);
   //SBMLNamespaces sbmlns;


### PR DESCRIPTION
`log` is referenced in `stream` so needs to be initialized before it, so its destructor will be called after `stream`'s destructor.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here, using the 'fixes #<issue>' syntax. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Change in documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have updated all documentation necessary.
- [ ] I have checked spelling in (new) comments.

## Testing
- [X] Testing is done automatically and codecov shows test coverage
- [ ] This cannot be tested automatically <!-- describe how it has been tested -->

